### PR TITLE
chassis: Support non-square drivebase

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -100,14 +100,9 @@ class SwerveModule:
         self.drive.config_kI(0, 0, 10)
         self.drive.config_kD(0, 0, 10)
 
-        # Configure encoder
-        self.encoder.configFeedbackCoefficient(
-            math.tau / 4096, "rad", ctre.SensorTimeBase.PerSecond, timeoutMs=10
-        )
-
     def get_angle_absolute(self) -> float:
-        """Gets steer angle from absolute encoder"""
-        return self.encoder.getAbsolutePosition()
+        """Gets steer angle (radians) from absolute encoder"""
+        return math.radians(self.encoder.getAbsolutePosition())
 
     def get_angle_integrated(self) -> float:
         """Gets steer angle from motor's integrated relative encoder"""
@@ -221,7 +216,6 @@ class Chassis:
                 CanIds.Chassis.drive_3,
                 CanIds.Chassis.steer_3,
                 CanIds.Chassis.encoder_3,
-                drive_reversed=True,
             ),
             # Front Right
             SwerveModule(
@@ -230,7 +224,6 @@ class Chassis:
                 CanIds.Chassis.drive_4,
                 CanIds.Chassis.steer_4,
                 CanIds.Chassis.encoder_4,
-                drive_reversed=True,
             ),
         ]
 

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -170,9 +170,9 @@ class SwerveModule:
 
 class Chassis:
     # metres between centre of left and right wheels
-    TRACK_WIDTH = 0.6167
+    TRACK_WIDTH = 0.54665
     # metres between centre of front and back wheels
-    WHEEL_BASE = 0.6167
+    WHEEL_BASE = 0.68665
 
     # maxiumum speed for any wheel
     max_wheel_speed = FALCON_FREE_RPS * SwerveModule.DRIVE_MOTOR_REV_TO_METRES

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -169,10 +169,11 @@ class SwerveModule:
 
 
 class Chassis:
-    # assumes square chassis
-    WIDTH = 0.6167  # meters between modules from CAD
-    # distace from center to wheels
-    WHEEL_DIST = math.sqrt(2) * WIDTH / 2
+    # metres between centre of left and right wheels
+    TRACK_WIDTH = 0.6167
+    # metres between centre of front and back wheels
+    WHEEL_BASE = 0.6167
+
     # maxiumum speed for any wheel
     max_wheel_speed = FALCON_FREE_RPS * SwerveModule.DRIVE_MOTOR_REV_TO_METRES
 
@@ -199,24 +200,24 @@ class Chassis:
         self.modules = [
             # Front Left
             SwerveModule(
-                self.WIDTH / 2,
-                self.WIDTH / 2,
+                self.WHEEL_BASE / 2,
+                self.TRACK_WIDTH / 2,
                 CanIds.Chassis.drive_1,
                 CanIds.Chassis.steer_1,
                 CanIds.Chassis.encoder_1,
             ),
             # Back Left
             SwerveModule(
-                -self.WIDTH / 2,
-                self.WIDTH / 2,
+                -self.WHEEL_BASE / 2,
+                self.TRACK_WIDTH / 2,
                 CanIds.Chassis.drive_2,
                 CanIds.Chassis.steer_2,
                 CanIds.Chassis.encoder_2,
             ),
             # Back Right
             SwerveModule(
-                -self.WIDTH / 2,
-                -self.WIDTH / 2,
+                -self.WHEEL_BASE / 2,
+                -self.TRACK_WIDTH / 2,
                 CanIds.Chassis.drive_3,
                 CanIds.Chassis.steer_3,
                 CanIds.Chassis.encoder_3,
@@ -224,8 +225,8 @@ class Chassis:
             ),
             # Front Right
             SwerveModule(
-                self.WIDTH / 2,
-                -self.WIDTH / 2,
+                self.WHEEL_BASE / 2,
+                -self.TRACK_WIDTH / 2,
                 CanIds.Chassis.drive_4,
                 CanIds.Chassis.steer_4,
                 CanIds.Chassis.encoder_4,


### PR DESCRIPTION
This splits the `WIDTH` constant into two: width and length between the wheels.