### PR TITLE
ids: Correct namespaces and use unique enums

### DIFF
--- a/components/arm.py
+++ b/components/arm.py
@@ -86,13 +86,13 @@ class Arm:
     def __init__(self) -> None:
         # Create rotation things
         self.rotation_motor = CANSparkMax(
-            CanIds.Arm.rotation_main, CANSparkMax.MotorType.kBrushless
+            CanIds.arm_rotation_main, CANSparkMax.MotorType.kBrushless
         )
         self.rotation_motor.setIdleMode(CANSparkMax.IdleMode.kCoast)
         self.rotation_motor.setInverted(False)
         # setup second motor to follow first
         self._rotation_motor_follower = CANSparkMax(
-            CanIds.Arm.rotation_follower, CANSparkMax.MotorType.kBrushless
+            CanIds.arm_rotation_follower, CANSparkMax.MotorType.kBrushless
         )
         self._rotation_motor_follower.follow(self.rotation_motor, invert=True)
         self._rotation_motor_follower.setIdleMode(CANSparkMax.IdleMode.kCoast)
@@ -103,7 +103,7 @@ class Arm:
             1 / self.ROTATE_GEAR_RATIO / 60
         )
 
-        self.absolute_encoder = DutyCycleEncoder(DioChannels.Arm.absolute_encoder)
+        self.absolute_encoder = DutyCycleEncoder(DioChannels.arm_absolute_encoder)
         self.absolute_encoder.setDistancePerRotation(math.tau)
         self.absolute_encoder.setPositionOffset(0)
 
@@ -121,7 +121,7 @@ class Arm:
 
         # Create extension things
         self.extension_motor = CANSparkMax(
-            CanIds.Arm.extension, CANSparkMax.MotorType.kBrushless
+            CanIds.arm_extension, CANSparkMax.MotorType.kBrushless
         )
         self.extension_motor.setIdleMode(CANSparkMax.IdleMode.kCoast)
         self.extension_motor.setInverted(False)

--- a/components/arm.py
+++ b/components/arm.py
@@ -1,7 +1,7 @@
 from magicbot import feedback, tunable
 from rev import CANSparkMax
 import wpilib
-from ids import CanIds, PcmChannels, DioChannels
+from ids import SparkMaxIds, PcmChannels, DioChannels
 import math
 from wpilib import (
     Solenoid,
@@ -86,13 +86,13 @@ class Arm:
     def __init__(self) -> None:
         # Create rotation things
         self.rotation_motor = CANSparkMax(
-            CanIds.arm_rotation_main, CANSparkMax.MotorType.kBrushless
+            SparkMaxIds.arm_rotation_main, CANSparkMax.MotorType.kBrushless
         )
         self.rotation_motor.setIdleMode(CANSparkMax.IdleMode.kCoast)
         self.rotation_motor.setInverted(False)
         # setup second motor to follow first
         self._rotation_motor_follower = CANSparkMax(
-            CanIds.arm_rotation_follower, CANSparkMax.MotorType.kBrushless
+            SparkMaxIds.arm_rotation_follower, CANSparkMax.MotorType.kBrushless
         )
         self._rotation_motor_follower.follow(self.rotation_motor, invert=True)
         self._rotation_motor_follower.setIdleMode(CANSparkMax.IdleMode.kCoast)
@@ -121,7 +121,7 @@ class Arm:
 
         # Create extension things
         self.extension_motor = CANSparkMax(
-            CanIds.arm_extension, CANSparkMax.MotorType.kBrushless
+            SparkMaxIds.arm_extension, CANSparkMax.MotorType.kBrushless
         )
         self.extension_motor.setIdleMode(CANSparkMax.IdleMode.kCoast)
         self.extension_motor.setInverted(False)

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -197,33 +197,33 @@ class Chassis:
             SwerveModule(
                 self.WHEEL_BASE / 2,
                 self.TRACK_WIDTH / 2,
-                CanIds.Chassis.drive_1,
-                CanIds.Chassis.steer_1,
-                CanIds.Chassis.encoder_1,
+                CanIds.drive_1,
+                CanIds.steer_1,
+                CanIds.swerve_encoder_1,
             ),
             # Back Left
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 self.TRACK_WIDTH / 2,
-                CanIds.Chassis.drive_2,
-                CanIds.Chassis.steer_2,
-                CanIds.Chassis.encoder_2,
+                CanIds.drive_2,
+                CanIds.steer_2,
+                CanIds.swerve_encoder_2,
             ),
             # Back Right
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 -self.TRACK_WIDTH / 2,
-                CanIds.Chassis.drive_3,
-                CanIds.Chassis.steer_3,
-                CanIds.Chassis.encoder_3,
+                CanIds.drive_3,
+                CanIds.steer_3,
+                CanIds.swerve_encoder_3,
             ),
             # Front Right
             SwerveModule(
                 self.WHEEL_BASE / 2,
                 -self.TRACK_WIDTH / 2,
-                CanIds.Chassis.drive_4,
-                CanIds.Chassis.steer_4,
-                CanIds.Chassis.encoder_4,
+                CanIds.drive_4,
+                CanIds.steer_4,
+                CanIds.swerve_encoder_4,
             ),
         ]
 

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -20,7 +20,7 @@ from wpimath.controller import SimpleMotorFeedforwardMeters
 
 from utilities.functions import constrain_angle, rate_limit_module
 from utilities.ctre import FALCON_CPR, FALCON_FREE_RPS
-from ids import CanIds
+from ids import CancoderIds, TalonIds
 
 
 class SwerveModule:
@@ -197,33 +197,33 @@ class Chassis:
             SwerveModule(
                 self.WHEEL_BASE / 2,
                 self.TRACK_WIDTH / 2,
-                CanIds.drive_1,
-                CanIds.steer_1,
-                CanIds.swerve_encoder_1,
+                TalonIds.drive_1,
+                TalonIds.steer_1,
+                CancoderIds.swerve_1,
             ),
             # Back Left
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 self.TRACK_WIDTH / 2,
-                CanIds.drive_2,
-                CanIds.steer_2,
-                CanIds.swerve_encoder_2,
+                TalonIds.drive_2,
+                TalonIds.steer_2,
+                CancoderIds.swerve_2,
             ),
             # Back Right
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 -self.TRACK_WIDTH / 2,
-                CanIds.drive_3,
-                CanIds.steer_3,
-                CanIds.swerve_encoder_3,
+                TalonIds.drive_3,
+                TalonIds.steer_3,
+                CancoderIds.swerve_3,
             ),
             # Front Right
             SwerveModule(
                 self.WHEEL_BASE / 2,
                 -self.TRACK_WIDTH / 2,
-                CanIds.drive_4,
-                CanIds.steer_4,
-                CanIds.swerve_encoder_4,
+                TalonIds.drive_4,
+                TalonIds.steer_4,
+                CancoderIds.swerve_4,
             ),
         ]
 

--- a/components/gripper.py
+++ b/components/gripper.py
@@ -9,13 +9,11 @@ class Gripper:
 
         self.solenoid = DoubleSolenoid(
             PneumaticsModuleType.CTREPCM,
-            ids.PcmChannels.Gripper.gripper_solenoid_forward,
-            ids.PcmChannels.Gripper.gripper_solenoid_reverse,
+            ids.PcmChannels.gripper_solenoid_forward,
+            ids.PcmChannels.gripper_solenoid_reverse,
         )
 
-        self.game_piece_switch = DigitalInput(
-            ids.DioChannels.Gripper.gripper_game_piece_switch
-        )
+        self.game_piece_switch = DigitalInput(ids.DioChannels.gripper_game_piece_switch)
 
     def open(self) -> None:
         self.opened = True

--- a/components/intake.py
+++ b/components/intake.py
@@ -11,7 +11,7 @@ class Intake:
         self.deployed = False
         self.break_beam = DigitalInput(ids.DioChannels.intake_break_beam_sensor)
         self.motor = CANSparkMax(
-            ids.CanIds.intake_motor, CANSparkMax.MotorType.kBrushless
+            ids.SparkMaxIds.intake_motor, CANSparkMax.MotorType.kBrushless
         )
         self.piston = DoubleSolenoid(
             PneumaticsModuleType.CTREPCM,

--- a/components/intake.py
+++ b/components/intake.py
@@ -9,14 +9,14 @@ class Intake:
 
     def __init__(self) -> None:
         self.deployed = False
-        self.break_beam = DigitalInput(ids.DioChannels.Intake.break_beam_sensor)
+        self.break_beam = DigitalInput(ids.DioChannels.intake_break_beam_sensor)
         self.motor = CANSparkMax(
-            ids.CanIds.Intake.intake_motor, CANSparkMax.MotorType.kBrushless
+            ids.CanIds.intake_motor, CANSparkMax.MotorType.kBrushless
         )
         self.piston = DoubleSolenoid(
             PneumaticsModuleType.CTREPCM,
-            ids.PcmChannels.Intake.intake_piston_forward,
-            ids.PcmChannels.Intake.intake_piston_reverse,
+            ids.PcmChannels.intake_piston_forward,
+            ids.PcmChannels.intake_piston_reverse,
         )
 
     def is_game_piece_present(self) -> bool:

--- a/ids.py
+++ b/ids.py
@@ -15,6 +15,8 @@ class CanIds:
     steer_4 = 8
     swerve_encoder_4 = 12
 
+
+class SparkMaxIds:
     arm_rotation_main = 13
     arm_rotation_follower = 14
     arm_extension = 15

--- a/ids.py
+++ b/ids.py
@@ -1,43 +1,35 @@
-import inspect
-
-
 class CanIds:
-    class Chassis:
-        drive_1 = 1
-        steer_1 = 5
-        encoder_1 = 9
+    drive_1 = 1
+    steer_1 = 5
+    swerve_encoder_1 = 9
 
-        drive_2 = 2
-        steer_2 = 6
-        encoder_2 = 10
+    drive_2 = 2
+    steer_2 = 6
+    swerve_encoder_2 = 10
 
-        drive_3 = 3
-        steer_3 = 7
-        encoder_3 = 11
+    drive_3 = 3
+    steer_3 = 7
+    swerve_encoder_3 = 11
 
-        drive_4 = 4
-        steer_4 = 8
-        encoder_4 = 12
+    drive_4 = 4
+    steer_4 = 8
+    swerve_encoder_4 = 12
 
-    class Arm:
-        rotation_main = 13
-        rotation_follower = 14
-        extension = 15
+    arm_rotation_main = 13
+    arm_rotation_follower = 14
+    arm_extension = 15
 
-    class Intake:
-        intake_motor = 16
+    intake_motor = 16
 
 
 class PcmChannels:
     arm_brake = 4
 
-    class Intake:
-        intake_piston_forward = 6
-        intake_piston_reverse = 7
+    intake_piston_forward = 6
+    intake_piston_reverse = 7
 
-    class Gripper:
-        gripper_solenoid_forward = 0
-        gripper_solenoid_reverse = 1
+    gripper_solenoid_forward = 0
+    gripper_solenoid_reverse = 1
 
 
 class PwmChannels:
@@ -45,26 +37,20 @@ class PwmChannels:
 
 
 class DioChannels:
-    class Gripper:
-        gripper_game_piece_switch = 0
+    gripper_game_piece_switch = 0
 
-    class Intake:
-        break_beam_sensor = 2
+    intake_break_beam_sensor = 2
 
-    class Arm:
-        absolute_encoder = 1
+    arm_absolute_encoder = 1
 
 
 # recursively get all attributes
 def get_ids(cls) -> list[int]:
-    # ignore dunders
-    attributes = [x for x in dir(cls) if not x.startswith("__")]
     ids = []
-    for att in attributes:
-        if inspect.isclass(getattr(cls, att)):
-            ids.extend(get_ids(getattr(cls, att)))
-        else:
-            ids.append(getattr(cls, att))
+    for name, value in vars(cls).items():
+        if name.startswith("_"):
+            continue
+        ids.append(value)
 
     return ids
 

--- a/ids.py
+++ b/ids.py
@@ -1,4 +1,8 @@
-class TalonIds:
+import enum
+
+
+@enum.unique
+class TalonIds(enum.IntEnum):
     drive_1 = 1
     steer_1 = 5
 
@@ -12,14 +16,16 @@ class TalonIds:
     steer_4 = 8
 
 
-class CancoderIds:
+@enum.unique
+class CancoderIds(enum.IntEnum):
     swerve_1 = 9
     swerve_2 = 10
     swerve_3 = 11
     swerve_4 = 12
 
 
-class SparkMaxIds:
+@enum.unique
+class SparkMaxIds(enum.IntEnum):
     arm_rotation_main = 13
     arm_rotation_follower = 14
     arm_extension = 15
@@ -27,7 +33,8 @@ class SparkMaxIds:
     intake_motor = 16
 
 
-class PcmChannels:
+@enum.unique
+class PcmChannels(enum.IntEnum):
     arm_brake = 4
 
     intake_piston_forward = 6
@@ -37,33 +44,15 @@ class PcmChannels:
     gripper_solenoid_reverse = 1
 
 
-class PwmChannels:
+@enum.unique
+class PwmChannels(enum.IntEnum):
     ...
 
 
-class DioChannels:
+@enum.unique
+class DioChannels(enum.IntEnum):
     gripper_game_piece_switch = 0
 
     intake_break_beam_sensor = 2
 
     arm_absolute_encoder = 1
-
-
-# recursively get all attributes
-def get_ids(cls) -> list[int]:
-    ids = []
-    for name, value in vars(cls).items():
-        if name.startswith("_"):
-            continue
-        ids.append(value)
-
-    return ids
-
-
-# enforce no duplicate ids
-def check_ids(*classes) -> None:
-    for cls in classes:
-        ids = get_ids(cls)
-        dups = {str(x) for x in ids if ids.count(x) > 1}
-        if dups:
-            raise ValueError("Duplicate Ids detected: " + ", ".join(dups))

--- a/ids.py
+++ b/ids.py
@@ -1,19 +1,22 @@
-class CanIds:
+class TalonIds:
     drive_1 = 1
     steer_1 = 5
-    swerve_encoder_1 = 9
 
     drive_2 = 2
     steer_2 = 6
-    swerve_encoder_2 = 10
 
     drive_3 = 3
     steer_3 = 7
-    swerve_encoder_3 = 11
 
     drive_4 = 4
     steer_4 = 8
-    swerve_encoder_4 = 12
+
+
+class CancoderIds:
+    swerve_1 = 9
+    swerve_2 = 10
+    swerve_3 = 11
+    swerve_4 = 12
 
 
 class SparkMaxIds:

--- a/physics.py
+++ b/physics.py
@@ -112,12 +112,12 @@ class PhysicsEngine:
             wpilib.PneumaticsModuleType.CTREPCM, PcmChannels.arm_brake
         )
 
-        self.arm_motor = SimDeviceSim("SPARK MAX ", CanIds.Arm.rotation_main)
+        self.arm_motor = SimDeviceSim("SPARK MAX ", CanIds.arm_rotation_main)
         self.arm_motor_pos = self.arm_motor.getDouble("Position")
         self.arm_motor_vel = self.arm_motor.getDouble("Velocity")
         self.arm_motor_output = self.arm_motor.getDouble("Applied Output")
 
-        self.arm_extension = SimDeviceSim("SPARK MAX ", CanIds.Arm.extension)
+        self.arm_extension = SimDeviceSim("SPARK MAX ", CanIds.arm_extension)
         self.arm_extension_pos = self.arm_extension.getDouble("Position")
         self.arm_extension_vel = self.arm_extension.getDouble("Velocity")
         self.arm_extension_output = self.arm_extension.getDouble("Applied Output")

--- a/physics.py
+++ b/physics.py
@@ -20,7 +20,7 @@ from wpimath.system.plant import DCMotor
 from components.chassis import SwerveModule
 from components import arm
 from utilities.ctre import FALCON_CPR, VERSA_ENCODER_CPR
-from ids import CanIds, PcmChannels
+from ids import PcmChannels, SparkMaxIds
 
 if typing.TYPE_CHECKING:
     from robot import MyRobot
@@ -112,12 +112,12 @@ class PhysicsEngine:
             wpilib.PneumaticsModuleType.CTREPCM, PcmChannels.arm_brake
         )
 
-        self.arm_motor = SimDeviceSim("SPARK MAX ", CanIds.arm_rotation_main)
+        self.arm_motor = SimDeviceSim("SPARK MAX ", SparkMaxIds.arm_rotation_main)
         self.arm_motor_pos = self.arm_motor.getDouble("Position")
         self.arm_motor_vel = self.arm_motor.getDouble("Velocity")
         self.arm_motor_output = self.arm_motor.getDouble("Applied Output")
 
-        self.arm_extension = SimDeviceSim("SPARK MAX ", CanIds.arm_extension)
+        self.arm_extension = SimDeviceSim("SPARK MAX ", SparkMaxIds.arm_extension)
         self.arm_extension_pos = self.arm_extension.getDouble("Position")
         self.arm_extension_vel = self.arm_extension.getDouble("Velocity")
         self.arm_extension_output = self.arm_extension.getDouble("Applied Output")

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,5 +1,0 @@
-import ids
-
-
-def test_duplicate_ids():
-    ids.check_ids(ids.CanIds, ids.PcmChannels, ids.PwmChannels, ids.DioChannels)


### PR DESCRIPTION
The `ids` module is intended to represent a one-to-one and onto mapping of individual named hardware bits to allocated IDs. Enums will model such a mapping with a unique constraint.

This refactors the `ids` module to use enums, and correctly namespace all the CAN resources.

Note to reviewers: reviewing the individual commits in this PR with "hide whitespace changes" turned on is recommended.