### PR TITLE
Update RobotPy and robotpy-photonvision

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,8 +8,8 @@ numpy = "~=1.24.1"
 robotpy-ctre = "~=2023.0.0"
 robotpy-navx = "~=2023.0.3"
 robotpy-rev = "~=2023.1.3.1"
-robotpy-photonvision = "~=2023.2.2"
-robotpy = {version = "~=2023.2.1.4", extras = ["apriltag", "cscore"]}
+robotpy-photonvision = "~=2023.3.0"
+robotpy = {version = "~=2023.3.2", extras = ["apriltag", "cscore"]}
 
 [dev-packages]
 hypothesis = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9662c533f059a4b172f9e86a65beec93714dd062edc7c94809d307419cbe8ed1"
+            "sha256": "7a386ff4f1f97920ee487b7885fb0e01ca671a0df22622b6b5a72fb643d39f11"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -130,32 +130,32 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:1a6915075c6d3a5e1215eab5d99bcec0da26036ff2102a1038401d6ef5bef25b",
-                "sha256:1ee1fd0de9851ff32dbbb9362a4d833b579b4a6cc96883e8e6d2ff2a6bc7104f",
-                "sha256:407cec680e811b4fc829de966f88a7c62a596faa250fc1a4b520a0355b9bc190",
-                "sha256:50386acb40fbabbceeb2986332f0287f50f29ccf1497bae31cf5c3e7b4f4b34f",
-                "sha256:6f97109336df5c178ee7c9c711b264c502b905c2d2a29ace99ed761533a3460f",
-                "sha256:754978da4d0457e7ca176f58c57b1f9de6556591c19b25b8bcce3c77d314f5eb",
-                "sha256:76c24dd4fd196a80f9f2f5405a778a8ca132f16b10af113474005635fe7e066c",
-                "sha256:7dacfdeee048814563eaaec7c4743c8aea529fe3dd53127313a792f0dadc1773",
-                "sha256:80ee674c08aaef194bc4627b7f2956e5ba7ef29c3cc3ca488cf15854838a8f72",
-                "sha256:844ad4d7c3850081dffba91cdd91950038ee4ac525c575509a42d3fc806b83c8",
-                "sha256:875aea1039d78557c7c6b4db2fe0e9d2413439f4676310a5f269dd342ca7a717",
-                "sha256:887cbc1ea60786e534b00ba8b04d1095f4272d380ebd5f7a7eb4cc274710fad9",
-                "sha256:ad04f413436b0781f20c52a661660f1e23bcd89a0e9bb1d6d20822d048cf2856",
-                "sha256:bae6c7f4a36a25291b619ad064a30a07110a805d08dc89984f4f441f6c1f3f96",
-                "sha256:c52a1a6f81e738d07f43dab57831c29e57d21c81a942f4602fac7ee21b27f288",
-                "sha256:e0a05aee6a82d944f9b4edd6a001178787d1546ec7c6223ee9a848a7ade92e39",
-                "sha256:e324de6972b151f99dc078defe8fb1b0a82c6498e37bff335f5bc6b1e3ab5a1e",
-                "sha256:e5d71c5d5bd5b5c3eebcf7c5c2bb332d62ec68921a8c593bea8c394911a005ce",
-                "sha256:f3ed2d864a2fa1666e749fe52fb8e23d8e06b8012e8bd8147c73797c506e86f1",
-                "sha256:f671c1bb0d6088e94d61d80c606d65baacc0d374e67bf895148883461cd848de",
-                "sha256:f6c0db08d81ead9576c4d94bbb27aed8d7a430fa27890f39084c2d0e2ec6b0df",
-                "sha256:f964c7dcf7802d133e8dbd1565914fa0194f9d683d82411989889ecd701e8adf",
-                "sha256:fec8b932f51ae245121c4671b4bbc030880f363354b2f0e0bd1366017d891458"
+                "sha256:0f8da300b5c8af9f98111ffd512910bc792b4c77392a9523624680f7956a99d4",
+                "sha256:35f7c7d015d474f4011e859e93e789c87d21f6f4880ebdc29896a60403328f1f",
+                "sha256:4789d1e3e257965e960232345002262ede4d094d1a19f4d3b52e48d4d8f3b885",
+                "sha256:5aa67414fcdfa22cf052e640cb5ddc461924a045cacf325cd164e65312d99502",
+                "sha256:5d2d8b87a490bfcd407ed9d49093793d0f75198a35e6eb1a923ce1ee86c62b41",
+                "sha256:6687ef6d0a6497e2b58e7c5b852b53f62142cfa7cd1555795758934da363a965",
+                "sha256:6f8ba7f0328b79f08bdacc3e4e66fb4d7aab0c3584e0bd41328dce5262e26b2e",
+                "sha256:706843b48f9a3f9b9911979761c91541e3d90db1ca905fd63fee540a217698bc",
+                "sha256:807ce09d4434881ca3a7594733669bd834f5b2c6d5c7e36f8c00f691887042ad",
+                "sha256:83e17b26de248c33f3acffb922748151d71827d6021d98c70e6c1a25ddd78505",
+                "sha256:96f1157a7c08b5b189b16b47bc9db2332269d6680a196341bf30046330d15388",
+                "sha256:aec5a6c9864be7df2240c382740fcf3b96928c46604eaa7f3091f58b878c0bb6",
+                "sha256:b0afd054cd42f3d213bf82c629efb1ee5f22eba35bf0eec88ea9ea7304f511a2",
+                "sha256:c5caeb8188c24888c90b5108a441c106f7faa4c4c075a2bcae438c6e8ca73cef",
+                "sha256:ced4e447ae29ca194449a3f1ce132ded8fcab06971ef5f618605aacaa612beac",
+                "sha256:d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695",
+                "sha256:e124352fd3db36a9d4a21c1aa27fd5d051e621845cb87fb851c08f4f75ce8be6",
+                "sha256:e422abdec8b5fa8462aa016786680720d78bdce7a30c652b7fadf83a4ba35336",
+                "sha256:ef8b72fa70b348724ff1218267e7f7375b8de4e8194d1636ee60510aae104cd0",
+                "sha256:f0c64d1bd842ca2633e74a1a28033d139368ad959872533b1bab8c80e8240a0c",
+                "sha256:f24077a3b5298a5a06a8e0536e3ea9ec60e4c7ac486755e5fb6e6ea9b3500106",
+                "sha256:fdd188c8a6ef8769f148f88f859884507b954cc64db6b52f66ef199bb9ad660a",
+                "sha256:fe913f20024eb2cb2f323e42a64bdf2911bb9738a15dba7d3cce48151034e3a8"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==39.0.0"
+            "version": "==39.0.1"
         },
         "exceptiongroup": {
             "hashes": [
@@ -280,25 +280,25 @@
         },
         "pyntcore": {
             "hashes": [
-                "sha256:057aa0f84d23cd7e1316800a8d69d03016ddd6a8745fc53b1212fbca28ed9ddd",
-                "sha256:1e96e31501ce96ea491a53da867bb2f9460a4cbfa90265b7eba1c5f347ffe958",
-                "sha256:1f832b534e36507cc5ac588f3a77a5c011f3dfa3026f9ce80f0398a21d51528f",
-                "sha256:5a83b714ad672d3d23bd6cec57704d580e8e121539a25d9db3a2a31b777b8ab6",
-                "sha256:6863ea19da141e330073ff91ac5117018abbbc57417ffc6470298d3941fb863c",
-                "sha256:75bf061b7fa9072c6c126b0b5888e7cefd5ebbac982e3b318b2bcb451194fb6f",
-                "sha256:8a930a983b70ca0c8b44a42e988e2ffff6d5602a8f6fb1b54ac880aaef9e6f1c",
-                "sha256:98a66520c0470dfd4a688960b7585c3a0c0a27becc5bd6236d434974dfe83eda",
-                "sha256:abfd27ec8888c49c812bb52659982b034a70a3441f24108ca5ca06031d3bcbf6",
-                "sha256:ac6675b480bab01fcce6ad42a21dcbe4b557a48c5b87d7179ebcb0453f3cea05",
-                "sha256:b623f3ff7805cb6f4d9aaabbd9a9cdf285ea2654abf3417ff98242cc8ca54517",
-                "sha256:c2d01965b06a81e677947917a3278b02d88a54ba5b367a1518227d6a1f692309",
-                "sha256:cad0b512e0cb8106c0eb2e27fe61032f5167c00699a90631580d36b3cdb11c7d",
-                "sha256:d52425b97fb76d632952570b9e5c5876514b977542020f48a89deb0699c40c79",
-                "sha256:dbfd099345dbc3a8fc6f3ef71fe9aa20b28060f3dcc93856223f570b0ef0afcb",
-                "sha256:f8e228f363a9aceaa5d19e9889ea3def752c82c02caa5465d34e61cf060cb912"
+                "sha256:026ab75259f2b06c327be17b72948aa16c1e1515846068742b77977c086e5618",
+                "sha256:0f1bce96df366cdd3b1bb7021ee4e95c94c54e4f0b388ae44d439647cfa85a2d",
+                "sha256:2a396d3d6f97b4d3b7b008ddd886bc28c1bc098972a43de49c2bdb9c08f9bbae",
+                "sha256:386c0c7f329f7463224cd1d31c4b70d91c20496ea6592305074a15aa40f9fe75",
+                "sha256:3cb3fe70ccf17cc7e3355a06e237a5738507acdacab32ed7c0e5dc3ece4e33a6",
+                "sha256:4b009b8fe974deffefc34e5e2ff0c82f35b033707d9613f2228dd48d071ba48a",
+                "sha256:5325d4f05c3aa545726e86eb452008e6071a5ccd0aa61f67dc39def3d23462b2",
+                "sha256:6a0833acdb1cdb91d87359f75092c62b9bc576a0f19afcdcefd6f817a7223d75",
+                "sha256:7ea2dc68445aadb7b69a74b58c0020d9c25dc44fb8bf8fe4d1e52042a099ce77",
+                "sha256:9d0235a55aa5624890d68eb742ae65b53e26b3af58f96956b94b7e234f2a92e8",
+                "sha256:aa8e6e4d4c348cd427d8954457e42da0a7b25bd173c95d939f8715bfa1f505a9",
+                "sha256:ac1ef0c02b771b0ce3593bb9283e07f8cfd8e57bd453e8239bb6936391bcebf2",
+                "sha256:b07dbe36d619f8b9920d2e702286f5015873f8647cfc112e8e34dc78e6f6f595",
+                "sha256:d32a5eb4b1dac1d37d338edbf748316daebe193c645ee18eec50250d4d260e28",
+                "sha256:f0cd45d068d556460d18b24d17beb09eaab426319bfc4cda4c1853c692dab159",
+                "sha256:f4453fabea11c29d6d5900bad8ed7588b6a95090b232979d597f09d908d47546"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.2.1.4"
+            "version": "==2023.3.2.1"
         },
         "pytest": {
             "hashes": [
@@ -322,53 +322,53 @@
                 "cscore"
             ],
             "hashes": [
-                "sha256:7255962c8d4d27b276373c00b126dc5c1c5678dc2aef6bae8fac708cbbc706f7",
-                "sha256:8c1e397ce714639c54192de6a1eafda50a0871e23e33398ebe785b4b64b590e1"
+                "sha256:0a8943f054e6ff3fff976195247cb7f0471920a607b8f49732dacfe6cfb0f947",
+                "sha256:3b5236651759ff3d59d69b5e52ea5a48d4870d7e09b21108cfe18a8e1d1f0b7a"
             ],
             "index": "pypi",
-            "version": "==2023.2.1.4"
+            "version": "==2023.3.2.1"
         },
         "robotpy-apriltag": {
             "hashes": [
-                "sha256:1cfebb05259037dfa76cbe3d56f3fb60e2b53dd9464348a70363241e5ab32116",
-                "sha256:37eef59fd000cca774ca2ea744ff2236e52842dc10db3be32ad53f8edae66419",
-                "sha256:7644ea2d6546743ccb4c072d110e83089708c29d936f9c49b3f85c8240e1d6b5",
-                "sha256:7bfde4df3f512fe355c5ffd3ec2d148c182e19839ba2be58af3c15aa1f74d9fc",
-                "sha256:845c281e19019c40c1f44a9aee4cc8b63dc1ae718b8176ba2d0b2776e0cbac2d",
-                "sha256:908074fb72bc0bd7c9679b3da0b123f949ba8e8a5c649f182f6a6549dc8dc6ed",
-                "sha256:92d7eb113f9cb97d886d21eff0ad276081d55cf92921caf793653b50f26ae55a",
-                "sha256:934b986a82cb8ab2f0bd0f3e186f9510a024d9108b0ed46accc52472446a6c03",
-                "sha256:bde34e16414b288339d54227b022e582e65a0c906886bbafa9640a9caa52e0bf",
-                "sha256:c11719825ca88ecb4e18166fefb4224d619d9ee9b29f06e3d9cc8f6df5f5a9f2",
-                "sha256:d3f4f4887e4191126b824b75ba0cd29ae1b4524daf30f0f9ba0d2495f18a5469",
-                "sha256:d8566c4a4f2dee39c10aa76a2874bddecb4f5c1531a200ccc2e66aa0a16f0c11",
-                "sha256:e663c8a9b6075808b55a09f4c7ade9b688c5b1c8d41a858ee436466c900372dc",
-                "sha256:ed6adfc5e3d5c3411c7538403db6c625cc71c1ad376c29796425cd401cd66aef",
-                "sha256:f15fbb0ee6a8bd10771a8f177a45214d7d9107d12ec3edbf335486c8ea10ea49",
-                "sha256:f1d2f3c89c7c7dcf15677f5aa36a8b01d7d6ff827b0f5c2fed0f98f230f28daf"
+                "sha256:13076113d2b4f9e8c09517d29ee89f4e52b19d5d461ff32d408387b5841e0a91",
+                "sha256:1931253e0c128395e30922a759c898bd864fe1a497e82f3c4d7cc7a246caf023",
+                "sha256:3bb109922d827c81d4732f3bd6e4655405d712178f7a0b1ca1b5626156b2f754",
+                "sha256:4181163d00b95edf7426238943b62987431ce62ba2d7c64782148708409ff9ad",
+                "sha256:44edd2b8a3b1781bc39f3cd3698a429e354b664a690b9939476cb11339971a92",
+                "sha256:4545020ffbcb5f92ffc4979c9e7d8062cd2db088c21bc78f0f19d0417a81d396",
+                "sha256:5496b083416831177b3971456893ad1ec8707f2dde11fb8494a370ea28eb8d58",
+                "sha256:620a1e5b9daa93ff25833cb26b36668f91e794897c020497a4317752b143c637",
+                "sha256:6d6cd452c9d399735017589b07bec4feed8757bdfde5d3c5fb754e2ff745502d",
+                "sha256:a1ad88cef9e20cbd2c395ed681428cdadc3b2123d38e6213981367fd9e20c866",
+                "sha256:af46cef6fdd60ce5091fc66454847e23eef94f0e8b173eaf00f56246d4664fa7",
+                "sha256:c0cb0b3221390ae72d086568be47b0bafb94602882d9c57f094cdccf8e627679",
+                "sha256:d4d3d7b15b7c0244ce236d856b30d90861f373c3f78c84188bd411a8dd39102e",
+                "sha256:e8676383b9fcd8181e60f0f5c38ec109b472c8aaba25a1704ac66fbd56bc5c2f",
+                "sha256:ed685c2fdea2f552a1129866bce1c8f19ad7ecc922dd80847d0351607822c2ec",
+                "sha256:f5a26d0f13fb145d395c16cdde84088cc01b80c90246242392bb0f07ebbee25f"
             ],
-            "version": "==2023.2.1.1"
+            "version": "==2023.3.2.1"
         },
         "robotpy-cscore": {
             "hashes": [
-                "sha256:0e98f9e74795352d33df3f72e8b961a58df555809e579eeb216136a718b6981b",
-                "sha256:1ef385364366b118dab8c5f143144e04b744aa3a2651650b131dbc99b651811f",
-                "sha256:400008b3be80f8012761b8db59f02c49b385ed0aa5fd055215495ada4498ec42",
-                "sha256:44350d8cec92b201a1405d7fdf467c6f994289132cf6272c93a217b374d1f62b",
-                "sha256:52a44316c11d88ff1cb9b1b26f9ed7383d604bd5036c04111ce6bd94540bff8f",
-                "sha256:ad3fd46b44a88bdd6c8ac7459bd870c08d4e4e763a6ffb2f4ff264c1afac36a7",
-                "sha256:b292224787e7dae306d1adb147f86ea81dd949fb484e93a621444d7b740b2040",
-                "sha256:b9fda31110d35ebba716253a6281d2c8cd5e489caf5e229037ecd1e93bd11f34",
-                "sha256:d9441369bece250efdb599bbfcb846d3cb5d8e223dd063f08acce8bc6634e8f5",
-                "sha256:e29c51f2f75b72ec771234fb69047ed0286bab4286f9f2376762afa77b6bba1a",
-                "sha256:e69518222bdc592871e75118dce82772eca96450abafac15799bd219410b5278",
-                "sha256:eb300cbd144fdacfc2eee1173c1b5822b193fecde3a00d9d20ad8497680945d2",
-                "sha256:ebd0c9f5b1fb2868b636702387df12396f5e5011a2c8e8c3ced98548dd95fa2d",
-                "sha256:f22176f7f1ea0faf93b0ea7029fe154d4b99cc4067ceb95d404c311c217b6387",
-                "sha256:f4895f4570d1e579eb7be9dd1b22b75587800e07cdaea0bcd0071e46030f4668",
-                "sha256:f812e9843a3733b90f46608bc23bc26f54dc843d288e0561eb4e69062da0d295"
+                "sha256:3437ffc8e61dc80e80ad72f4186cc48e62164ac5d68d51e745e082e3f7db13c9",
+                "sha256:426076d92218896807a1426783baef59107295fbd78ba5957bbf248d9f4986cc",
+                "sha256:487a3cc4f284b086d359ad81234c560252f2fc5fe5380c8038d056cbfae8b526",
+                "sha256:599bf74209c79f734298fd4e1ce6f80aa37b4c414dd70d0be30949ce08d3724b",
+                "sha256:6b3a6bca48c1165e628c7d9e9ddd97c53a1a6203e4681d5b1497c0c7b2d17f3a",
+                "sha256:6b825829ccff5481edb48332bb05397822b59ac4f08c1b397f6b104dbfe397c7",
+                "sha256:78d628e5e0da88c9ee0fe4358024c06345ddabc76740a993668ffca233be5e8c",
+                "sha256:816de621cfd45794dcd97d468ad10484d8bf9eac36b199109e5c1b0c9f227685",
+                "sha256:c222d7d3ed4f388921f58ad1ccf37cdbed5163a8043af51e0dafde4d9af4fde2",
+                "sha256:c2a8c55a2c63b9759c84855436b102c0505a599031e756cb69c1e8c7febbd5ad",
+                "sha256:e29603839277d0c02076adc8ce6b6a25a3a10932989448474ffd591b6f885b0a",
+                "sha256:f0c4695f554e703d0519dea1b2515b0344d1902ea2850ad44bbbc9fbabb8f5e4",
+                "sha256:f473e47d4c0878ba3459961ee06de028548629166c38615b66dfc92073f0f8c5",
+                "sha256:fb9ecdb06bd8a8df1006c9e2cde73e81dc6f685c0560af5af792ea52c32a0f3f",
+                "sha256:fbc096c3c687c88ec88440f3c7872ecec8df6b1f7ec6c7c3de60c53e20afa225",
+                "sha256:fe7ec9b5107946d24544266ec73a2d2ae8ce46dd1ccf695d99d7d53956d1aa51"
             ],
-            "version": "==2023.2.1.1"
+            "version": "==2023.3.2.1"
         },
         "robotpy-ctre": {
             "hashes": [
@@ -394,47 +394,47 @@
         },
         "robotpy-hal": {
             "hashes": [
-                "sha256:3fa14db333a0e6a3c82d06167a304e8858756c63798a27be7c6bc488137c1040",
-                "sha256:44d72d155e79a78678d2d7dd4f6fe33a647d039a2e4f148f590b532886b72274",
-                "sha256:4ad29cec9c9d4b4288d267833d28ecc10f7acc6fc1be497cf5514a5647865d74",
-                "sha256:663313b66c703f8f2b12f09756319e9453e1124c9cf9c920b58596aa0be7d66b",
-                "sha256:66b46af22b88ef6892f28e425687992ea9c1160f5319e59e27a04402ddf83025",
-                "sha256:72bf5377d21af2aca57731e1d2edaf7f26e239576021ef3bd708b909d30c402c",
-                "sha256:73c970f1826d0d54ee889b497e4a56726e6fc668208485db4b3cd0f06fee19fe",
-                "sha256:7758317dceeb09b9a58db2f96515ed476d45539ad346af1c8fb3b40544a7c01a",
-                "sha256:840450e481863ccd8fb3261c970e35bc54c3c442354f650fcec9ea7e2e1b6c73",
-                "sha256:8842d0bf3c026e2a07c8d0b9717d115c1a14f79f233e6e736429d2501473a00a",
-                "sha256:953b2f354ebd98d9b45e23e4124bcac8a9cfb12f2cc03e2229866939aa8607aa",
-                "sha256:aa5597578aab03e5e3df86c7f1da221fc7520ce8bd9259448a933581c8ce86dd",
-                "sha256:ac90bbb6a2770a4156a132495ae68f76f4681a8d842b2e0e566ad6c4503e0a11",
-                "sha256:cf150a76701ad6f2622aedc29811760988b24d42de35bbbc310ae2464c5f2a13",
-                "sha256:d10245082d191d1f6a0be3d97d08557dbf3f0a2f0514545d63d09cb2442fed3f",
-                "sha256:d11acbb956c654e95eb80996763e4a5e5445affdab0c1a07e27978a79bda5e92"
+                "sha256:1e3359685f51b3b53b57366452c863f62404a1afd83349d813ba0c551be10ad4",
+                "sha256:2a9177774bb00c7d2130919665f7066a86668322d3bbba78ebd4e42b25b399be",
+                "sha256:346a8d555635082d8548c4a6ab48305dbac1239a7a79541fc7145693bfc72c26",
+                "sha256:41f3a1cc2a248ca5de153279142acba5bbdcb8d07d0dc2d5ffcaf78b46e5b411",
+                "sha256:42c70a6a7159b0976a0c8b71e64f19a417d264a5f923687a2f02ba3cbac838d2",
+                "sha256:4bd8f95d188e1397b5d123ec11870d871508fdee0556cac228bc0efeaa05d975",
+                "sha256:7b539a0aebbcc4a960c23b1f50f5aa95f1e308d598dba6ba7671ead7b7ea3798",
+                "sha256:9c24759b9f59168321742eecdaad02e1eddeeb9fe563e1dc0c46c3e3e8170757",
+                "sha256:a5b8588fc719560008bf1c5d23c41430dfad9d40dfb76ed48e9a939630899a12",
+                "sha256:bbd814cc9381607e63963a2c21feaccf4b033f3ef01e39385ea106bac3df64f0",
+                "sha256:bcbad81e571dc2e75b174dcab76c438faf5cec4484bc87bf026fa893f9e221b6",
+                "sha256:c820487c7eba77c8456f703682a3d57a35c96fee948765569412fac11a8cb4ac",
+                "sha256:cdc2602f387f6c6fd4f0d9eb252f3ec62fef67c3b3147ed897af66c060599511",
+                "sha256:daf2b4b796d95f4c777a1d0ab2270d40c74aec14f64cebfc83c830d132a930a7",
+                "sha256:dbf0bb981d89befaba923436b105635678d49af38aff208e6d09fb8fbdc6ef4e",
+                "sha256:f5ff98d8d65a1c59c320dfcf41decb1aa0e4555c7e164ea2d520b587393b73db"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.2.1.1"
+            "version": "==2023.3.2.1"
         },
         "robotpy-halsim-gui": {
             "hashes": [
-                "sha256:175ddba153bf32e5c320bee79ec8dd3c16e0cdff218f16c2cc9ddc27f48de9c8",
-                "sha256:314ca6ec4741bfa082965f10eab6bdf3afd3b4601cb4db73625f5bc5ee06de31",
-                "sha256:3a74f1686a38e7d0ef426648bb5372bcab06bf591e937ef4e90ec1c42fc1ea19",
-                "sha256:62dab74f4b8cb9d9a0f822c5f523f37b9dbff69b84fc4bb6018f3f2a15fe73aa",
-                "sha256:7fa9aac711bd1cff38bec47350321b5909da82c0379721e9162d881f87e05703",
-                "sha256:85bdc7bd186a3c53c71ecdf83b641de86c34cb13994ad74f77edd97b82b6d0d8",
-                "sha256:8ec550e13378473c0821e9f2fa62e7a3274c754b5d1fe7bddf5bb9bda1f7a737",
-                "sha256:8ede7edc29ee84094464892798c1f4e95177ebc56b42c5fe77db789b4a6ef374",
-                "sha256:9260ae039c0d360635d1378a1499c9483e47f8910064d6637e5dcc72d4dc3eed",
-                "sha256:98b50b351b982992b97584b89c26f637707e62ad14a4a0544b557284a605fd11",
-                "sha256:a7d1e672e33646c9a27100562cc084710738071f9ac53f0d46b0add939e10c63",
-                "sha256:ad2bcc06f32eacfebfa4da2dd650a483776983d61232861d42194af564addf1c",
-                "sha256:c2172103ab1ad3e405bea51a08cff9bb84c8205de2354f46e2fd3ce03036325f",
-                "sha256:d3fe645a989bd1c5d41fc3754243cc2157c83b7f4e7546c932fcd5ae3f6eb0d6",
-                "sha256:e63b65bcc69da1e3a6e5d884e74718fee0a03870d77bf7cf55d43c99b7a19474",
-                "sha256:e8567e49c85f7636c857ce8d85b87e9ad27beadf2d9296547f43dfe0a179cd95"
+                "sha256:1dc29d999642821f30c5189a3b93404f7eba26d57edb7fdeb775bdc3722a004d",
+                "sha256:1f94fd4ec2007bc7c1903cd392acea9292830446dfd42172169a68c519682176",
+                "sha256:3705a930ff0a11a881d5d7073a020474d41712bcb9dcc4f4668fe5d0d60f5d51",
+                "sha256:3a9f38f74b1c1462a0173f10938e47665b7159671a7e720bcf00e325033f2af0",
+                "sha256:48639df8cb0e62ce4a6844efa4f32bb9b0c1d0621fccab6dbc5eb7ea6b4165fa",
+                "sha256:64c09565a5d490515873b03cd06c301414cfd7b9a4d8263718a840ea1ebe8c78",
+                "sha256:6eb11e2f2f289866b085a6ff1d4c8ea4a7edc4b8d8ef33f0471b148056bd3caf",
+                "sha256:7261c47fc5f9d9c62404e0cfff357e989006c180f10008b7d4dfeb3e6d367a5c",
+                "sha256:99816a637a03ad663d1ce1f0d06824ac495a32321220fab42a32711d65c415d3",
+                "sha256:a39291d51d6823c1b19bcbd0f601253b44391102aa2f9dd882f76a01c114e333",
+                "sha256:b8a3e79d5a8f48d04a32f7d4252ec80075ed578610df113b0310b99b64643b92",
+                "sha256:bdd17fe6849f6daf2c1a9bf1c7e29577892215acb76e7b71e36c42962c0d00ae",
+                "sha256:df617fb8b47bef4af275790f784ffdf263853b71555d7030135312c95f7de30a",
+                "sha256:ea6c8a62983e5e08108992a8f89b86d6640b1ebaabb94157abb6cb2bd38e1ae8",
+                "sha256:f6207d398f3202c39b63cc77f73707ddeb518a11f165def2cac1004669dfcb4d",
+                "sha256:fd07178345c5280ae9ac148d380cb5e3eebb1676a57789bcc7d470ef7840db81"
             ],
             "markers": "platform_machine != 'armv7l'",
-            "version": "==2023.2.1.1"
+            "version": "==2023.3.2.1"
         },
         "robotpy-installer": {
             "hashes": [
@@ -468,25 +468,25 @@
         },
         "robotpy-photonvision": {
             "hashes": [
-                "sha256:02dd2230f6be37f13abffb7525ef380e854bec50c1d171e9e6c0bd3ccb44a044",
-                "sha256:20f73c0adece5c97622c47ce8554cfa19ec7d132efc97b391545d282aaa15fbe",
-                "sha256:249e126635e1c7ca0cff94034770294ff81b4d6b00b0d0dde9ffcdab1e292c18",
-                "sha256:288fe87832d9777c5ea4527344fcdaf8cb7a5deb360aa4a44773739f0dcde7b7",
-                "sha256:5a42efe75cb98e007ea078dfe677bbcf8c1d15fe1d7ba54136372b996802c528",
-                "sha256:5ee33c8fc32f850b99f27c1ec4e7586bfcbbccba30e71da25626afd9c72c4a32",
-                "sha256:6ede3f93a948a16e18f40cdeba9dc999573dcb7106c37e2fc84d8002bf03b416",
-                "sha256:8991360b64c4c9ac45cb3689382acb54a60dc5d49fa82442326580950fe56eca",
-                "sha256:9ed25f717ab55f6f1c5292130b5118bad7e0555259b8e80931f879e45163d436",
-                "sha256:a0f41deb4dec1f6b00d80a98032e273eff3ccb32130d2997cc4a74d0f7dc99e0",
-                "sha256:a7236f1e58e136ac83ac76682aa58270b94d4f81143359ba15c6434e9068ddc6",
-                "sha256:bae13b9284639acdeb48f7da8aafb99033db5993c508f9812b60f5323676468a",
-                "sha256:c046cd5b8ab6b8bde15b035ae809b48ef576f9ff239259ef3c968b8286855062",
-                "sha256:c3b59f29cc2274f7ac6e4624caddf60ea035bafb26f6ee620c5540aa42e537a0",
-                "sha256:da506e215518033348ba81d4c255bf56ffb2859eb0784933ad7cf720543cbc50",
-                "sha256:e1be4449215f67206cb11743055e17454e17daa7b02a5ef5e89d8e00076919d8"
+                "sha256:0f7ce65899f129f6ca364d861d2b74401d261732c400170f742816f8680de83b",
+                "sha256:22514636a5c282eaba3d67a9e0cd118d749b849f26501ba737108410cbb5a901",
+                "sha256:35e3233d143c9b568e777561e9467dbb87de3bb786558afd8fadb58e64a77b5c",
+                "sha256:38d1812208476357f2da7b490721ff4bd04f99ae8f189d3653f04fdf79d4d593",
+                "sha256:3dcab4380ac99f94cb75c896038bea43629523ab6cc48bf279a92e7102b451c5",
+                "sha256:3e2034f1ba150c286361b5b30fd3bee6cda7d68dee4b3811849822b2a39a253d",
+                "sha256:48a02d426c0bdddad9f9772449a7416fa9026aec367dcb3f5fc1400444e14f20",
+                "sha256:4c4d78e709dbf9c6db793f48fd12249c10a07e2ea71c1cf1262ed38d85d23573",
+                "sha256:604b331b7b3416401f2fd0588f21de0314282d473f4ec14b1ce548da2b3bc722",
+                "sha256:672fdf9c59936f55688095f1824dba337762895146b06bddf7bc7ce71b5a4539",
+                "sha256:6c8e89a8eb2f13d80833708e74cd80faea4a1030d2533cbd0136f622a40ca567",
+                "sha256:7269249b8a2a4827d11a3ddacd941f6fdf3ad919ed4b39b710d9d07aeea2f696",
+                "sha256:93fc717624203b97fffce74b64d03e1dea426d4644db0b6551fa690d58389afe",
+                "sha256:cfc696cd2bb4ec21a5fab22c49bde9bc9f9750130890e20a7acb6b3c86279935",
+                "sha256:d08ea5c874ecd75493c4f17a7d43bb1a2628d5c5f7ff453813869bb0fe74a4db",
+                "sha256:eca1d2d10c6c1847ec7368acd719948cf2efe9c6c03db81d9c3bf6d3089ee712"
             ],
             "index": "pypi",
-            "version": "==2023.2.2"
+            "version": "==2023.3.0"
         },
         "robotpy-rev": {
             "hashes": [
@@ -520,69 +520,69 @@
         },
         "robotpy-wpimath": {
             "hashes": [
-                "sha256:17c7589f69a3e5c3d026e10e8946975fecfa61552fe786a5ada6617d6b7645fd",
-                "sha256:2aa03563faab960192a96d856f79cce479da6cdcaf220935f572fabf6d18d553",
-                "sha256:3ce25264703147e2104b5d0e9b267e4934b1d14aee6a6d91f601d1d67d3f81e1",
-                "sha256:42595b92325c02d36a4bba78808f91daec571eb580e168a2ca5b9e97f8d2d1b2",
-                "sha256:4c0ddeea487b5f88bebabb39669b4a98d5f7de81e3931ce95b18b32145fbfc78",
-                "sha256:66f4f9a9743879c51585d3004fc17b8ca85d3136c97e0c90d3afad28ea7d2288",
-                "sha256:6b94babe6483baaef062bbbc7d7854056b56a35db70f1d6c4d8bfef57a3f2196",
-                "sha256:6e2bd8f0c4a638a25aeb79529424ed5db593c927985561a4d5248a4b61412e89",
-                "sha256:81a82985d8866a985c0a1f1349d635a6e368e2f8cce22318f041c0004bac0cf0",
-                "sha256:86444f3a29d62637f44fcbbc244898d6062499f3d26322e295d914f05e6dc190",
-                "sha256:a8c2bd0a6fd6c0c41494d564a5ec34a52ab9ecaff6f159c3c6e4b08e40b58c1c",
-                "sha256:b27a05550e07746bc20055c0d713677f24dae434f8873185296617d2cd5cd308",
-                "sha256:d00fb236a6cc07a514583778501ff5a7de6b59405b1b9c6be74e6294f851fa75",
-                "sha256:e6fcf71d761c4b00a16199a28bdf01200b808226e113a6646357c9d463eed58d",
-                "sha256:f1717ca094c15321e7c36968f73c956bb86640e002ab46219904d8f0673746dd",
-                "sha256:f49976034007b920ebee007d31ab0c5243cc2f662e8b33dfa90092dbac669829"
+                "sha256:1f8722041ed58fe354f69f89fa6e2f2be678ad9f45fbef6e885316788f643d85",
+                "sha256:340abced64bb82ff79f0d095222a1286465f75998e8f892efd810b1c47477eac",
+                "sha256:35d067ae840e96abf92c434ca82b8b920c19f1d391dd61666c4c0b82b69f08c2",
+                "sha256:35ffda6249803393e8e41124ed2af07f1a8219a522d77ba341103eed44ffa505",
+                "sha256:3f127ed09c8fc9f10509967aee04ca335dd184b2535738c1223d0b2d5e587d10",
+                "sha256:47f23a7acf0fb00291fb36fde94d4db675c808e71a548bb11be421c1c6dfc189",
+                "sha256:4e7636fcc681f2cacaa2d7293d564e4b4e13c2a7b67473103513fc4999447932",
+                "sha256:83c5cba44981d4dc9653a8a345d20b4998c3f5286757292cc98bb2c2044ac4f8",
+                "sha256:970a366be0865b73d36d187db2529c6a3b36cd2e8a20767d1824ca45b498dbaa",
+                "sha256:974468fb8a898928d2d3db26a9e5af9f88542517ce1facc8547d3c87aac41bf5",
+                "sha256:a5f98a13005ad36cf83acff69f34a865177a3fc75899be9bc7017bbf547ac497",
+                "sha256:a9875bec5f25671a5ea5e2440bfbde84030105ad670a2618f3dc49eb1e0119bd",
+                "sha256:c1f2408891e23653196b1b446f9d89dd40d99614d32f42c2c49c62d86958473d",
+                "sha256:c2f72d116f1d1b5da28ae727fe21dead95f6b3469d266e76b5183cca4a82b5fb",
+                "sha256:e8d27ab0e8cfbd36bd41c1bacebf0ca27e622f58f7c1423acb805da80abdf9fa",
+                "sha256:f2fe31c08669cb29763c92cf022bc02fefe7c7678a891f93567380d864e0cfee"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.2.1.1"
+            "version": "==2023.3.2.1"
         },
         "robotpy-wpinet": {
             "hashes": [
-                "sha256:19e718ac4e83a8ccbbd6d6a1011708d8d15ad7de06c121051d8dfda177ec748c",
-                "sha256:36b491daf7e8406b781b8b80fdadb210f88ab7387677906f70e7fca528d53214",
-                "sha256:51b00902dac3c5dd861e542f3c07acbb956d3d59005a39946a120209d0b80db1",
-                "sha256:52f5c1e8b34d138b79384966db2af972e2d30658034f44ea90d4c2878c2ad2f8",
-                "sha256:5787878c5fae2d11e864aae7b9c277c9657e9a088bff86bd4824aee81145cf25",
-                "sha256:7b37ba8f05d0a5eb581d942388f38190538973403a0135038d5a7a738d625aba",
-                "sha256:86bdccb3637602462b8678f20d0b1b2ecc955c7845ca89a20a9032487fb428c3",
-                "sha256:94554c83c05536079c6aa2557185a7c7cd14b0e1e8c59e2d7de07508b9d668bc",
-                "sha256:b2080c7a42126bfc307654ec687a07a83f6b7a3c84c0792df3df1329aa427201",
-                "sha256:b239c37a1cce72c4ff00d9a57988b9924690d50ed2a57e00f6bdbbcec6b0f797",
-                "sha256:bf6c62dfdf6f6c998ba0dccdd62437aa5bae3421ce3b84e16159051250d70a90",
-                "sha256:c7ec891d77b2e432b0a41d211d98208bcdd7a49e4966eb866a215586c6b4c902",
-                "sha256:e0e63da81f85d940b2934f5b761cc5b4c2b0ddc10003115ffa560dbac5325125",
-                "sha256:f9307e532dc3e2af95c99b56277ef1ee3b4ed137e45a6fe8380e6e82e88cb761",
-                "sha256:f973f98a42d29ebf7b3ca413af15f1476f11470f48e54d2dc8045b0e0b5daf0d",
-                "sha256:ffbcea709d700612ecde28f59eec23e4ebaf0dd7b746de0b0f3ace59d5a0b696"
+                "sha256:136ce9986adfa4a4818013b239a9f961e79ff0430260fb13f534e085206d4304",
+                "sha256:19d7e8c3b42dacb8eb0fa002fc1bf23bb29935a47d239e15c16beca69da384bc",
+                "sha256:1b8f1522ddd14dfb9834c919d5c8da13cc72771c40b98cac36d36c4f77078acc",
+                "sha256:2791f221b69d172e7ca303e5da5e7986327401f933a2901c4944e0fd8eef1ad8",
+                "sha256:370ae79a09ef29fc4db5e95ce64f191efbc33130487b3cb7667b8a0d4f41e4f9",
+                "sha256:5c7864baec3e248ef28b602afcc343e921c9ead751750eff4e1f51f906e13ed3",
+                "sha256:65621c93f867dc1a0bb3055b35a95bbe8293d0a2b7cb73538ef89b2e69dbb615",
+                "sha256:79a215e4718867da833cd1eee0daf00ab6b84cb171768ac7f822aa5e5034d0c0",
+                "sha256:7bfbc22b381b2241f94896a71e5fdd927eaed863e461df86ad53f8f92cde2d88",
+                "sha256:84775ccf557e1f51404fdb0617a25f16fcffef4fcebc236e637240a16df26595",
+                "sha256:93336a86dad67eca0357406e584cf63f9cbe99acdb35d280c708c2f3b400418c",
+                "sha256:b5d62d97a17385421bb573ff09918a2c8d8dd09afe351aefb03030a84f61f97b",
+                "sha256:c865c62b3c536bd93caf5d3b744535d480699ea3fd868845ebf34b73b27dd764",
+                "sha256:da3e21892fe3120723b8f30b3689034bb1dbc0ba6ab233a8e102d0efff1b9c1c",
+                "sha256:ee4e8edaf456228362831e1081e8f3dd30c4d174c6f928eb9290fc545daa3299",
+                "sha256:f06ad8091bc18830b5f4fe78fce181807e6b3911624c43dbab652353dc6c36e0"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.2.1.1"
+            "version": "==2023.3.2.1"
         },
         "robotpy-wpiutil": {
             "hashes": [
-                "sha256:02eee6cf4dadb524214d7387d941718eb8ebe27f7ddbdc1b7bb6ba2d4c42da1d",
-                "sha256:02f7ec7a6b2266e1b1c884dca86f1cd8f93fd23da491193088a0a237bc1a160f",
-                "sha256:1173bd633807f8fd526fafb19efd26ad49aadcfe1a6388883dfa1f775e1357a9",
-                "sha256:193e05663332405f9877ddabb64f7f4fc6d8dc131678f6fa38af09551b61e0aa",
-                "sha256:3cb69c71d9f640989dad7c73e372116ca5b335bc423e07041b6b1b0b7104ab01",
-                "sha256:3ceff126ace961a0921b3b627da428cd9a59923cca55fa5271af0ea05030ec3d",
-                "sha256:3eace831727ccbe69f5223cacbaa2f1a4407059f5334e4b5f606e6afc5209943",
-                "sha256:42763fbd6cfb55c639ade4d0f8ec3a45d31f54afdc6f983244fcc45399273952",
-                "sha256:5da74c7002d740b64861d0fda9405f8e11b3b19c61fb13908a4400de38209519",
-                "sha256:8a34fde1c647702cf12a37fbb55a794e6cec95b8d00f1dc044bbf66261cd50f9",
-                "sha256:962a1b9d6f30019c67df950e6c1eee4a043c5d6a112e7498ba18244ef6b09299",
-                "sha256:a26c85971ec1e8a400cf7188086ae1c7c034d090828340419fd061252b63c51d",
-                "sha256:b69a0d3a4638daa4bd65fe7902b2c4c7324248321a5b8b682c69f74895d0e286",
-                "sha256:d2db34293c191d2d4a00ada82b016d30e9f0bfda3d91738618c40f879d9712f7",
-                "sha256:ed540facb4213af0fb84337640120e8c96231b857da1632ce44e7829583a5914",
-                "sha256:f642925fdc858c21d40c0cbc361748157ab56971112938e219d00c2d2c27272a"
+                "sha256:0895802214c5c6e4b490e0d911440c0f52aaf32996314c9f9976a52265c2c928",
+                "sha256:11c2bc23d058e4159c9f70b91596b6f4b7e2b96d01010e0010133b8f426aa0f1",
+                "sha256:14d86d67a27e87f8b885b726042a3afa2fdcf45f33528c6a2375facf4da6bb4a",
+                "sha256:5d98d72a953d3a5043d32eb9d880c9f39eb045e6f2031463fcaa35d9b95bbb43",
+                "sha256:685107cbc2559d5b2ec0fa1995787e794b3c72a1985b05a69d96ac29fad84ca3",
+                "sha256:6c71e02e8020fb724b1624ec8e5c9e317f4f855a30d44478c549fd5826bdb011",
+                "sha256:73a4428ca2aa40d81f29db2437d64b0a9bad7f7802b59b22229380c87019e990",
+                "sha256:787c6addbd846116b000089a63ea9ef1f033872451b83fc1ba3b3bb6a2490bd2",
+                "sha256:937305eb9f0291ba0318c665e6d78f0afa26dedf25984f664204451f96e2fc51",
+                "sha256:956654d03e7a29a79e3b1b19d43e18c6db4d4e1a6531631ec5df9cca0eccda61",
+                "sha256:99a666119d629f6fd16dbe7b88d567e1c32db9727e162def7e88453ab49b4b59",
+                "sha256:c8fd8ca9932b6c5827e871ad6b4c52def26a99e3874a2e1ccc10310ea5200a3a",
+                "sha256:ce48c8dc90e753db93894406f21c3b81da92795a15ecc0906e4639f95982d92d",
+                "sha256:d511c2fe9b1c5c19de2657f3fad220b9e89a5a21b7e4ed77ac8752454108f5be",
+                "sha256:de6c7916a949029324e38c3fe15ff8104c86736104eb086565f3dfce3ae0efd5",
+                "sha256:ed0938555cac31f03d6a5128c1ed940bbe7c3f7771303f19a12ea5f744460b37"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.2.1.1"
+            "version": "==2023.3.2.1"
         },
         "tomli": {
             "hashes": [
@@ -594,25 +594,25 @@
         },
         "wpilib": {
             "hashes": [
-                "sha256:0e6097858f96e82bd9a85157348be1e5fc7caa774d32696b3adb4cf5c6c312fd",
-                "sha256:26ba0cdef5484386df70754aeb5013e6db2c51cc59081487d6cccf16fb748379",
-                "sha256:44cd46a47f3a48ed5f39ed9a3720cf563044245bf92bc7b3b2f3c57a911cffde",
-                "sha256:45019526162c09e3c70f07b5c12ee7f353944e86badeeeb78e3f99868d9a6fba",
-                "sha256:47292bae01e08ea645b05bfe771e84ed5b509c780e0e4cf66d5c9432db6b097d",
-                "sha256:4f5b7f526d24f1dce0f28bda05e08bfba92097a298b93be35d6d1cf4c15ac363",
-                "sha256:59a11236bdea0949caffabf6e8089cb5027214558ac09496e4716cb1c6fdaa98",
-                "sha256:63689f818ef6ffcc285f9610dea5e37b20a0ed342315c55409eade10f28a9e42",
-                "sha256:7b1f98d3ff5a0947fa46c01c3ca1e7a5c554d66084d3a43f9e2b3d90eb435cab",
-                "sha256:97e7c7ff5c33ba8cec91b8cc8d6defb34e046c9b9d9209bd8d5c6c9ced6ee897",
-                "sha256:9dbabffe8d36965ac10875aed050e8c0e069699d0db02757ae35cc446f88fc90",
-                "sha256:9f42c2870f75a787d00d61c100e54208f072504cbc2b7d18876846e26cd1cba3",
-                "sha256:a2c351690b6c4fac4cba55842f148ddb978ff81ddef8afdff38f7e82d794f3fd",
-                "sha256:acfab215fe8712650d5175f38fc31b7d826d4bc8961f42a584524aa2647a8d97",
-                "sha256:e6fa7c7b0d910138d0ad4e33766fc580ae0f97281c8ad81ebcfef91988e6e854",
-                "sha256:fa4846df8eb310c5ab0bb2f9f49a8b365dc8924c8b9f78e98d050b0b9067b44a"
+                "sha256:0311a2f02842fb593757b0cae2d3e812d7539e1936795e685f95ff8b03098cc1",
+                "sha256:15a84e7d784d5fcbfed2f4f5b47c69cf602630ee7f8a8674b77efcc98de8a49d",
+                "sha256:19b28f5f91af85c65277f6e79d2d4b8ca1225d9ef5411d159781a501e20330cf",
+                "sha256:2e051743ff3f09bd474d8c89eb5596fafc2fc7fbb350d0fe5fb4200f47013654",
+                "sha256:55d7e804fbe9b565395cb1e98f47163d616c799931a011db8302e991b7dd6dde",
+                "sha256:5a7496ea6402899d833ae9ff56949e05b0905404faaf1c9dfded40ef6398329b",
+                "sha256:775060c11afbcfd3ac52490a987bc36d6df3fbb3b30648f01670de715b9ce898",
+                "sha256:8ce6e688775cf0051c778eef8cd76de9d94675516806a0609658daf0e83593e6",
+                "sha256:afd2e9bca95b977477406565698ba4743728cd2f588e830fbf81f6099d001d76",
+                "sha256:ca5a8505bdddd040001037ec8079b11299d4fc0b64f56de94d1616f1a393ff6f",
+                "sha256:d971dce82dbc46f4c3ace25702e393d8e248f8d60e903ed09e3be3504870506a",
+                "sha256:d9ef0500d62109933d4c48ed95e6ba9260152ae5de03ac4de40bb290ceaccf72",
+                "sha256:e0166e19993379e1164a05ae6a9a39d12e3d96afbf6a0a4b54f4ce0e6db45e38",
+                "sha256:e4b8333189bf7d250dbad9aace1023aede4aa40939958e454b1305ad9e6b4b0b",
+                "sha256:ee6d9a92af079d95cf903801d6c4c99da4edd3a39623fa6d8b1dce292ba69563",
+                "sha256:fe69fb80907a875ec6b88280f15ba1b985febc8b5304ac20eaf2093527da7495"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.2.1.1"
+            "version": "==2023.3.2.1"
         }
     },
     "develop": {
@@ -634,11 +634,11 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:7abb4361d796ae6432d1c0b22a514210a2a19cb0d85efca8463e619a80f3132c",
-                "sha256:947839d8b5fd24d9b4d1e41ee10f7285d023f49f3b318519bf110fa9e5f3154e"
+                "sha256:064a5bf7a98cbdfa3589d8934a2c548524c6d108bfa368ec5ed8b09caa526108",
+                "sha256:8cfa1de15271debb2750545a460e58e3e84527d94157f38ab9309826953572f3"
             ],
             "index": "pypi",
-            "version": "==6.67.1"
+            "version": "==6.68.0"
         },
         "iniconfig": {
             "hashes": [

--- a/physics.py
+++ b/physics.py
@@ -80,16 +80,14 @@ class PhysicsEngine:
         # Create arm simulation
         arm_motors_sim = DCMotor.NEO(2)
         arm_len = (arm.MIN_EXTENSION + arm.MAX_EXTENSION) / 2
-        arm_mass = 5
-        moi = SingleJointedArmSim.estimateMOI(arm_len, arm_mass)
+        arm_moi = SingleJointedArmSim.estimateMOI(arm_len, mass=5)
         self.arm_sim = SingleJointedArmSim(
             arm_motors_sim,
             robot.arm.ROTATE_GEAR_RATIO,
-            moi,
+            arm_moi,
             arm_len,
             -arm.MAX_ANGLE - math.radians(10),
             -arm.MIN_ANGLE,
-            arm_mass,
             simulateGravity=True,
             measurementStdDevs=[math.radians(0.01)],
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy~=1.24.1
-robotpy[apriltag,cscore]~=2023.2.1.4
+robotpy[apriltag,cscore]~=2023.3.2
 robotpy-ctre~=2023.0.0
 robotpy-navx~=2023.0.3
 robotpy-rev~=2023.1.3.1
-robotpy-photonvision~=2023.2.2
+robotpy-photonvision~=2023.3.0


### PR DESCRIPTION
This updates the robot to [WPILib 2023.3.2](https://github.com/wpilibsuite/allwpilib/releases/tag/v2023.3.2), and updates PhotonLib to 2023.3.0 to match the coprocessor.