### PR TITLE
Fix field locations derrived from alliance enum

### DIFF
--- a/utilities/game.py
+++ b/utilities/game.py
@@ -83,7 +83,7 @@ for row in Rows:
 
 
 def get_nodes(alliance: wpilib.DriverStation.Alliance) -> list[list[Translation3d]]:
-    if alliance is wpilib.DriverStation.Alliance.kBlue:
+    if alliance == wpilib.DriverStation.Alliance.kBlue:
         return BLUE_NODES
     else:
         return RED_NODES
@@ -104,7 +104,7 @@ DOUBLE_SUBSTATION_BLUE_DRIVER = field_flip_translation3d(DOUBLE_SUBSTATION_RED_D
 
 
 def get_double_substation(alliance: wpilib.DriverStation.Alliance, wall_side: bool):
-    if alliance is wpilib.DriverStation.Alliance.kBlue:
+    if alliance == wpilib.DriverStation.Alliance.kBlue:
         if wall_side:
             return DOUBLE_SUBSTATION_BLUE_WALL
         else:
@@ -121,7 +121,7 @@ SINGLE_SUBSTATION_BLUE = field_flip_translation2d(SINGLE_SUBSTATION_RED)
 
 
 def get_single_substation(alliance: wpilib.DriverStation.Alliance) -> Translation2d:
-    if alliance is wpilib.DriverStation.Alliance.kBlue:
+    if alliance == wpilib.DriverStation.Alliance.kBlue:
         return SINGLE_SUBSTATION_BLUE
     else:
         return SINGLE_SUBSTATION_RED


### PR DESCRIPTION
stop checking is equal where it isnt appropriate because bindings don't like this at all