### PR TITLE
chassis: Squash ctre.sensors warning

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -93,7 +93,7 @@ class SwerveModule:
         self.drive.enableVoltageCompensation(True)
         self.drive_ff = SimpleMotorFeedforwardMeters(kS=0.18877, kV=2.7713, kA=0.18824)
         self.drive.configVelocityMeasurementPeriod(
-            ctre.SensorVelocityMeasPeriod.Period_5Ms
+            ctre.sensors.SensorVelocityMeasPeriod.Period_5Ms
         )
         self.drive.configVelocityMeasurementWindow(8)
         self.drive.config_kP(0, 0.011489, 10)

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -3,6 +3,7 @@ import math
 import time
 from typing import Optional
 
+import ctre
 import ctre.sensors
 import magicbot
 import navx


### PR DESCRIPTION
Fixes the warning
```
  /home/runner/work/pychargedup/pychargedup/components/chassis.py:96: FutureWarning: ctre.SensorVelocityMeasPeriod has moved to ctre.sensors
    ctre.SensorVelocityMeasPeriod.Period_5Ms
```
Example run: https://github.com/thedropbears/pychargedup/actions/runs/4261451599/jobs/7415790319#step:5:71