### PR TITLE
physics: Grab arm constants directly

### DIFF
--- a/physics.py
+++ b/physics.py
@@ -89,7 +89,7 @@ class PhysicsEngine:
         )
         self.arm_sim = SingleJointedArmSim(
             arm_motors_sim,
-            robot.arm.ROTATE_GEAR_RATIO,
+            arm.Arm.ROTATE_GEAR_RATIO,
             arm_moi,
             arm_len,
             -arm.MAX_ANGLE - math.radians(10),
@@ -102,9 +102,9 @@ class PhysicsEngine:
         ELEVATOR_CARRIAGE_MASS = 0.655
         self.extension_sim = ElevatorSim(
             extension_motors_sim,
-            robot.arm.EXTEND_GEAR_RATIO,
+            arm.Arm.EXTEND_GEAR_RATIO,
             ELEVATOR_CARRIAGE_MASS + END_EFFECTOR_MASS,
-            robot.arm.SPOOL_CIRCUMFERENCE / math.tau,
+            arm.Arm.SPOOL_CIRCUMFERENCE / math.tau,
             arm.MIN_EXTENSION,
             arm.MAX_EXTENSION,
             simulateGravity=False,


### PR DESCRIPTION
Stop accessing arm constants from `robot.arm`.