### PR TITLE
ci: Use pytest-forked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-          pip install coverage pytest-github-actions-annotate-failures
-      - run: python robot.py coverage test -- -v
+          pip install coverage pytest-forked pytest-github-actions-annotate-failures
+      - run: python robot.py coverage test -- -v --forked
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
Avoid tests deadlocking in CI when robot code crashes.