### PR TITLE
ci: Split coverage run from forked tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
           pip install coverage pytest-forked pytest-github-actions-annotate-failures
-      - run: python robot.py coverage test -- -v --forked
+      - run: python robot.py test -- -v --forked
+      - run: python robot.py coverage test -- -v
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Context

pytest-forked prevents coverage.py from working correctly without [parallel mode](https://coverage.readthedocs.io/en/7.1.0/cmd.html#cmd-combine).

pyfrc will automatically run `coverage report`, however this is useless if parallel mode is enabled without running `coverage combine` first. A PR has been raised to add a command line option to do this: https://github.com/robotpy/pyfrc/pull/219

We use pytest-forked in CI to avoid the tests deadlocking when the robot code raises an exception, and to compensate for the fact that [GitHub Actions doesn't allow reading historical logs from currently running steps](https://github.com/orgs/community/discussions/44250).

## Solution

A simpler solution: we can collect coverage without `--forked` after running with `--forked` has passed.

This will of course roughly double the time to run tests, but the coverage collection process will be much simpler.