### PR TITLE
Enable pytest faulthandler timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
+faulthandler_timeout = 15
 pythonpath = '.'
 
 [tool.ruff]


### PR DESCRIPTION
We have a non-deterministically hanging test. Hopefully using faulthandler after a timeout will help us figure out what's going on.

https://docs.pytest.org/en/stable/how-to/failures.html#fault-handler